### PR TITLE
Update rules to get object spread

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ module.exports = {
   "parserOptions": {
     "ecmaVersion": 8,
     "sourceType": "module",
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true,
+    }
   },
 
   "rules": {


### PR DESCRIPTION
Node > 8.6.0 appears to have object spread built in, but our eslint rules do not allow it at the moment. I would like to use it in some work I'm doing and we use it all over the place in tools so I figured may as well add it.

While I was at it, I saw that our eslint config misses a lot of useful rules such as `no-unused-vars` and `no-undef`, so I added the `eslint:recommended` rules. This will create a decent amount of work when upgrading since a lot of these don't have `--fix` abilities, but it seems worth it ultimately.

Happy to take or leave either one, what do you think?