### PR TITLE
Add rules on unnesessary semicolons and strict equality operator

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ module.exports = {
     "new-cap": 0,
     "comma-spacing": [2, {"before": false, "after": true}],
     "comma-dangle": [2, "always-multiline"],
-    "eqeqeq": [2, "always"],
+    "eqeqeq": [2, "always", {"null": "ignore"}],
     "no-extra-semi": 2
   }
 }

--- a/index.js
+++ b/index.js
@@ -47,6 +47,8 @@ module.exports = {
     "new-cap": 0,
     "comma-spacing": [2, {"before": false, "after": true}],
     "comma-dangle": [2, "always-multiline"],
+    "eqeqeq": [2, "always"],
+    "no-extra-semi": 2
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-taskcluster",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": "Brian Stack <bstack@mozilla.com>",
   "description": "Shared eslint config for Taskcluster projects",
   "license": "MPL-2.0",


### PR DESCRIPTION
I'll be honest here: I'm not sure what the numbers mean here everywhere. For example, `comma-dangle` rule, according to documentation, can have a string parameter and/or an object parameter. but here it has an array with a number and a string 🤔 So I also stuck an array and a number everywhere for consistency, and I chose `2` because that occurs most often. An explanation and/or correction would be much appreciated!