### PR TITLE
Use newer Ecmascript version

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ module.exports = {
   },
 
   "parserOptions": {
-    "ecmaVersion": 8,
+    "ecmaVersion": 9,
     "sourceType": "module",
     "ecmaFeatures": {
       "experimentalObjectRestSpread": true,


### PR DESCRIPTION
I am using the spread operator to construct an object literal, which is available in ECMA 2018 only.